### PR TITLE
메이플스토리 오픈 API 이용하여 진행중 이벤트 목록/ 상세보기 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.0.4",
         "@prisma/client": "^6.4.0",
+        "axios": "^1.7.9",
         "bcrypt": "^5.1.1",
         "cheerio": "^1.0.0",
         "passport": "^0.7.0",
@@ -4587,8 +4588,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/b4a": {
       "version": "1.6.7",
@@ -5436,7 +5447,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5795,7 +5805,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6169,7 +6178,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7141,6 +7149,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -7255,7 +7283,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7281,7 +7308,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7291,7 +7317,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7714,7 +7739,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -10445,6 +10469,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.0.4",
     "@prisma/client": "^6.4.0",
+    "axios": "^1.7.9",
     "bcrypt": "^5.1.1",
     "cheerio": "^1.0.0",
     "passport": "^0.7.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,13 +2,18 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './modules/auth/auth.module';
-import { TwitterService } from './modules/twitter/twitter.service';
-import { TwitterController } from './modules/twitter/twitter.controller';
 import { TwitterModule } from './modules/twitter/twitter.module';
+import { MapleModule } from './modules/maple/maple.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
-  imports: [AuthModule, TwitterModule],
-  controllers: [AppController, TwitterController],
-  providers: [AppService, TwitterService],
+  imports: [
+    AuthModule,
+    TwitterModule,
+    MapleModule,
+    ConfigModule.forRoot({ isGlobal: true }),
+  ],
+  controllers: [AppController],
+  providers: [AppService],
 })
 export class AppModule {}

--- a/src/modules/maple/dto/event_notice.dto.ts
+++ b/src/modules/maple/dto/event_notice.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class EventNoticeDto {
+  @ApiProperty({
+    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    description: '공지 제목',
+  })
+  title: string;
+
+  @ApiProperty({
+    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    description: '공지 링크',
+  })
+  url: string;
+
+  @ApiProperty({
+    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    description: '공지 본문',
+  })
+  contents: string;
+
+  @ApiProperty({
+    example: '2023-12-21T00:00+09:00',
+    description: '공지 등록일(시)(KST)',
+  })
+  date: string;
+
+  @ApiProperty({
+    example: '2023-12-21T00:00+09:00',
+    description: '이벤트 시작일(시) (KST)',
+  })
+  date_event_start: string;
+
+  @ApiProperty({
+    example: '2023-12-21T00:00+09:00',
+    description: '이벤트 종료일(시) (KST)',
+  })
+  date_event_end: string;
+}

--- a/src/modules/maple/dto/event_notice.dto.ts
+++ b/src/modules/maple/dto/event_notice.dto.ts
@@ -2,13 +2,13 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class EventNoticeDto {
   @ApiProperty({
-    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    example: '[챔피언 버닝] - 챔피언 더블 업 & 챌린지',
     description: '공지 제목',
   })
   title: string;
 
   @ApiProperty({
-    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    example: 'https://maplestory.nexon.com/News/Event/1103',
     description: '공지 링크',
   })
   url: string;

--- a/src/modules/maple/dto/event_notice_list.dto.ts
+++ b/src/modules/maple/dto/event_notice_list.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class EventNoticeListDto {
+  @ApiProperty({
+    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    description: '공지 제목',
+  })
+  title: string;
+
+  @ApiProperty({
+    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    description: '공지 링크',
+  })
+  url: string;
+
+  @ApiProperty({
+    example: 1,
+    description: '공지 식별자',
+  })
+  notice_id: number;
+
+  @ApiProperty({
+    example: '2023-12-21T00:00+09:00',
+    description: '공지 등록일(시)(KST)',
+  })
+  date: string;
+
+  @ApiProperty({
+    example: '2023-12-21T00:00+09:00',
+    description: '이벤트 시작일(시) (KST)',
+  })
+  date_event_start: string;
+
+  @ApiProperty({
+    example: '2023-12-21T00:00+09:00',
+    description: '이벤트 종료일(시) (KST)',
+  })
+  date_event_end: string;
+}

--- a/src/modules/maple/dto/event_notice_list.dto.ts
+++ b/src/modules/maple/dto/event_notice_list.dto.ts
@@ -2,19 +2,19 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class EventNoticeListDto {
   @ApiProperty({
-    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    example: '[챔피언 버닝] - 챔피언 더블 업 & 챌린지',
     description: '공지 제목',
   })
   title: string;
 
   @ApiProperty({
-    example: 'League of Legends (@LeagueOfLegends) / Twitter',
+    example: 'https://maplestory.nexon.com/News/Event/1103',
     description: '공지 링크',
   })
   url: string;
 
   @ApiProperty({
-    example: 1,
+    example: 1103,
     description: '공지 식별자',
   })
   notice_id: number;

--- a/src/modules/maple/dto/maple.controller.ts
+++ b/src/modules/maple/dto/maple.controller.ts
@@ -1,8 +1,9 @@
 import { HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { EventNoticeListDto } from './event_notice_list.dto';
+import { EventNoticeDto } from './event_notice.dto';
 
-export function ApiGetMapleEventNotices() {
+export function ApiGetManyEventNotices() {
   return function (target: any, key: string, descriptor: PropertyDescriptor) {
     HttpCode(HttpStatus.OK)(target, key, descriptor);
     ApiOperation({
@@ -13,6 +14,66 @@ export function ApiGetMapleEventNotices() {
       status: 200,
       description: '메이플스토리 진행중 이벤트 목록 조회 성공',
       type: [EventNoticeListDto],
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 400,
+      description: 'Bad Request',
+      schema: {
+        example: {
+          statusCode: 400,
+          name: '',
+          message: '',
+        },
+      },
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 403,
+      description: 'Forbidden',
+      schema: {
+        example: {
+          statusCode: 403,
+          name: '',
+          message: '',
+        },
+      },
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 429,
+      description: 'Too Many Requests',
+      schema: {
+        example: {
+          statusCode: 429,
+          name: '',
+          message: '',
+        },
+      },
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 500,
+      description: '서버 오류',
+      schema: {
+        example: {
+          statusCode: 500,
+          message:
+            '메이플스토리 진행중 이벤트 데이터를 가져오는 중 오류가 발생했습니다.',
+          error: 'Internal Server Error',
+        },
+      },
+    })(target, key, descriptor);
+  };
+}
+
+export function ApiGetEventNotice() {
+  return function (target: any, key: string, descriptor: PropertyDescriptor) {
+    HttpCode(HttpStatus.OK)(target, key, descriptor);
+    ApiOperation({
+      summary: '메이플스토리 진행중 이벤트 상세 조회',
+      description: '메이플스토리 진행 중 이벤트 게시글 세부 사항을 조회합니다.',
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 200,
+      description: '메이플스토리 진행중 이벤트 게시글 세부 사항 조회 성공',
+      type: EventNoticeDto,
     })(target, key, descriptor);
     ApiResponse({
       status: 400,

--- a/src/modules/maple/dto/maple.controller.ts
+++ b/src/modules/maple/dto/maple.controller.ts
@@ -1,0 +1,63 @@
+import { HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { EventNoticeListDto } from './event_notice_list.dto';
+
+export function ApiGetMapleEventNotices() {
+  return function (target: any, key: string, descriptor: PropertyDescriptor) {
+    HttpCode(HttpStatus.OK)(target, key, descriptor);
+    ApiOperation({
+      summary: '메이플스토리 진행중 이벤트 목록 조회',
+      description: '진행중인 이벤트 목록 20개를 가지고 옵니다.',
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 200,
+      description: '메이플스토리 진행중 이벤트 목록 조회 성공',
+      type: [EventNoticeListDto],
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 400,
+      description: 'Bad Request',
+      schema: {
+        example: {
+          statusCode: 400,
+          name: '',
+          message: '',
+        },
+      },
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 403,
+      description: 'Forbidden',
+      schema: {
+        example: {
+          statusCode: 403,
+          name: '',
+          message: '',
+        },
+      },
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 429,
+      description: 'Too Many Requests',
+      schema: {
+        example: {
+          statusCode: 429,
+          name: '',
+          message: '',
+        },
+      },
+    })(target, key, descriptor);
+    ApiResponse({
+      status: 500,
+      description: '서버 오류',
+      schema: {
+        example: {
+          statusCode: 500,
+          message:
+            '메이플스토리 진행중 이벤트 데이터를 가져오는 중 오류가 발생했습니다.',
+          error: 'Internal Server Error',
+        },
+      },
+    })(target, key, descriptor);
+  };
+}

--- a/src/modules/maple/maple.controller.ts
+++ b/src/modules/maple/maple.controller.ts
@@ -1,7 +1,10 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { MapleService } from './maple.service';
-import { ApiGetMapleEventNotices } from './dto/maple.controller';
+import {
+  ApiGetManyEventNotices,
+  ApiGetEventNotice,
+} from './dto/maple.controller';
 
 @ApiTags('maple')
 @Controller('maple')
@@ -9,8 +12,14 @@ export class MapleController {
   constructor(private mapleService: MapleService) {}
 
   @Get()
-  @ApiGetMapleEventNotices()
-  async getMapleEventNotices() {
+  @ApiGetManyEventNotices()
+  async getManyEventNotice() {
     return await this.mapleService.fetchManyEventNotice();
+  }
+
+  @Get(':notice_id')
+  @ApiGetEventNotice()
+  async getEventNotice(@Param('notice_id', ParseIntPipe) notice_id: number) {
+    return await this.mapleService.fetchEventNotice({ notice_id });
   }
 }

--- a/src/modules/maple/maple.controller.ts
+++ b/src/modules/maple/maple.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { MapleService } from './maple.service';
+import { ApiGetMapleEventNotices } from './dto/maple.controller';
+
+@ApiTags('maple')
+@Controller('maple')
+export class MapleController {
+  constructor(private mapleService: MapleService) {}
+
+  @Get()
+  @ApiGetMapleEventNotices()
+  async getMapleEventNotices() {
+    return await this.mapleService.fetchManyEventNotice();
+  }
+}

--- a/src/modules/maple/maple.module.ts
+++ b/src/modules/maple/maple.module.ts
@@ -4,6 +4,6 @@ import { MapleService } from './maple.service';
 
 @Module({
   controllers: [MapleController],
-  providers: [MapleService]
+  providers: [MapleService],
 })
 export class MapleModule {}

--- a/src/modules/maple/maple.module.ts
+++ b/src/modules/maple/maple.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MapleController } from './maple.controller';
+import { MapleService } from './maple.service';
+
+@Module({
+  controllers: [MapleController],
+  providers: [MapleService]
+})
+export class MapleModule {}

--- a/src/modules/maple/maple.service.ts
+++ b/src/modules/maple/maple.service.ts
@@ -21,6 +21,34 @@ export class MapleService {
       console.error('Error Status:', error.response?.status);
       console.error('Error Message:', error.response?.data?.error?.message);
       console.error('Error Headers:', error.response?.headers);
+
+      return error;
+    }
+  }
+
+  async fetchEventNotice({ notice_id }: { notice_id: number }) {
+    const MAPLE_API_SERVER = 'https://open.api.nexon.com/maplestory/v1';
+    const API_KEY = process.env.MAPLE_API_KEY;
+
+    const instance = axios.create({
+      baseURL: MAPLE_API_SERVER,
+    });
+
+    try {
+      const { data } = await instance.get(
+        '/notice-event/detail?notice_id=' + notice_id,
+        {
+          headers: { 'x-nxopen-api-key': API_KEY },
+        },
+      );
+
+      return data;
+    } catch (error) {
+      console.error('Error Status:', error.response?.status);
+      console.error('Error Message:', error.response?.data?.error?.message);
+      console.error('Error Headers:', error.response?.headers);
+
+      return error;
     }
   }
 }

--- a/src/modules/maple/maple.service.ts
+++ b/src/modules/maple/maple.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+@Injectable()
+export class MapleService {
+  async fetchManyEventNotice() {
+    const MAPLE_API_SERVER = 'https://open.api.nexon.com/maplestory/v1';
+    const API_KEY = process.env.MAPLE_API_KEY;
+
+    const instance = axios.create({
+      baseURL: MAPLE_API_SERVER,
+    });
+
+    try {
+      const { data } = await instance.get('/notice-event', {
+        headers: { 'x-nxopen-api-key': API_KEY },
+      });
+
+      return data;
+    } catch (error) {
+      console.error('Error Status:', error.response?.status);
+      console.error('Error Message:', error.response?.data?.error?.message);
+      console.error('Error Headers:', error.response?.headers);
+    }
+  }
+}


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] **메이플 스토리 오픈 API 진행 중인 이벤트 목록 API 구현**
  - [x] **메이플 스토리 오픈 API 진행 중인 이벤트 상세 보기 API 구현**

---

# 🤔 논의가 필요한 사항 (Points to discuss)

<!-- 논의가 필요한 사항, 개선해야 할 부분을 작성해주세요. -->
- [ ] controller 부분 따로 빼서 작성은 했는데 원하는대로 에러코드가 나오지는 않는 중이라 수정해야 될 것 같아요.
- [ ] 같은 코드를 두 번씩 작성 해서 그 부분 리팩토링 해야 될 것 같습니다.

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **기능 A**                  | **기능 B**                  |
|-----------------------------|-----------------------------|
| ![기능 A 스크린샷](https://github.com/user-attachments/assets/ad0dd7de-0db2-4dd9-a9dd-bcec8f53e373)    | ![기능 B 스크린샷](https://github.com/user-attachments/assets/de098b22-d3d6-443e-982a-3fdfda93cc7e)    |

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->
- **테스트 방법**:
  1. `http://localhost:3000/maple` : 공지 목록 20개 확인하기
  2. `http://localhost:3000/maple/:notice_id` : 공지 목록에서의 notice_id로 검색
- **참고 자료**: [링크](https://openapi.nexon.com/ko/game/maplestory/?id=24)
