### PR TITLE
최신 도서 목록, 상세 보기 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { MapleModule } from './modules/maple/maple.module';
 import { ConfigModule } from '@nestjs/config';
 import { MovieModule } from './modules/movie/movie.module';
 import { KopisModule } from './modules/kopis/kopis.module';
+import { BookModule } from './modules/book/book.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { KopisModule } from './modules/kopis/kopis.module';
     ConfigModule.forRoot({ isGlobal: true }),
     MovieModule,
     KopisModule,
+    BookModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/book/book.controller.ts
+++ b/src/modules/book/book.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { BookService } from './book.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { GetBookDetailDto } from './dto/get-book-detail.dto';
 
 @ApiTags('book')
 @Controller('book')
@@ -8,7 +9,20 @@ export class BookController {
   constructor(private bookService: BookService) {}
 
   @Get()
+  @ApiOperation({
+    summary: '최신 도서 목록 조회',
+    description: '국내/ 외국/ eBook 목록 10개씩 조회',
+  })
   async getManyBook() {
     return await this.bookService.fetchManyBook();
+  }
+
+  @Get('/detail')
+  @ApiOperation({
+    summary: '도서 상세 조회',
+    description: 'isbn13코드로 도서 상세 조회',
+  })
+  async getBook(@Query() { isbn13 }: GetBookDetailDto) {
+    return await this.bookService.fetchBook({ isbn13 });
   }
 }

--- a/src/modules/book/book.controller.ts
+++ b/src/modules/book/book.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { BookService } from './book.service';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('book')
+@Controller('book')
+export class BookController {
+  constructor(private bookService: BookService) {}
+
+  @Get()
+  async getManyBook() {
+    return await this.bookService.fetchManyBook();
+  }
+}

--- a/src/modules/book/book.controller.ts
+++ b/src/modules/book/book.controller.ts
@@ -1,7 +1,11 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { BookService } from './book.service';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { GetBookDetailDto } from './dto/get-book-detail.dto';
+import {
+  AladinBookDetailDto,
+  AladinBookResponseDto,
+} from './dto/book.controller.dto';
 
 @ApiTags('book')
 @Controller('book')
@@ -13,6 +17,11 @@ export class BookController {
     summary: '최신 도서 목록 조회',
     description: '국내/ 외국/ eBook 목록 10개씩 조회',
   })
+  @ApiResponse({
+    status: 200,
+    description: '성공',
+    type: AladinBookResponseDto,
+  })
   async getManyBook() {
     return await this.bookService.fetchManyBook();
   }
@@ -21,6 +30,11 @@ export class BookController {
   @ApiOperation({
     summary: '도서 상세 조회',
     description: 'isbn13코드로 도서 상세 조회',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '성공',
+    type: AladinBookDetailDto,
   })
   async getBook(@Query() { isbn13 }: GetBookDetailDto) {
     return await this.bookService.fetchBook({ isbn13 });

--- a/src/modules/book/book.module.ts
+++ b/src/modules/book/book.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { BookController } from './book.controller';
+import { BookService } from './book.service';
+import { HttpModule } from '@nestjs/axios';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [BookController],
+  providers: [BookService],
+})
+export class BookModule {}

--- a/src/modules/book/book.service.ts
+++ b/src/modules/book/book.service.ts
@@ -57,7 +57,7 @@ export class BookService {
   }
 
   async fetchManyBook() {
-    const books = await this.fetchManyBookData({
+    const domesticBooks = await this.fetchManyBookData({
       SearchTarget: 'Book',
       endpoint: 'ItemList.aspx',
     });
@@ -71,7 +71,7 @@ export class BookService {
     });
 
     return {
-      books: books.item,
+      domesticBooks: domesticBooks.item,
       foreignBooks: foreignBooks.item,
       eBooks: eBooks.item,
     };

--- a/src/modules/book/book.service.ts
+++ b/src/modules/book/book.service.ts
@@ -1,0 +1,65 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class BookService {
+  private readonly ALADIN_API_SERVER =
+    'http://www.aladin.co.kr/ttb/api/ItemList.aspx';
+
+  constructor(
+    private configService: ConfigService,
+    private httpService: HttpService,
+  ) {}
+
+  private fetchBookApiKey(): string {
+    const aladinApiKey = this.configService.get<string>('ALADIN_API_KEY');
+
+    if (!aladinApiKey) {
+      throw new InternalServerErrorException(
+        '서버 설정 오류: ALADIN_API_KEY가 환경변수에 정의되지 않았습니다.',
+      );
+    }
+
+    return aladinApiKey;
+  }
+
+  private async fetchManyBookData({ SearchTarget }: { SearchTarget: string }) {
+    try {
+      const queryString = new URLSearchParams({
+        ttbkey: this.fetchBookApiKey(),
+        QueryType: 'ItemNewAll',
+        SearchTarget,
+        start: '1',
+        MaxResults: '10',
+        output: 'js',
+        Version: '20131101',
+      }).toString();
+      const url = `${this.ALADIN_API_SERVER}?${queryString}`;
+
+      const { data } = await firstValueFrom(this.httpService.get(url));
+
+      return data;
+    } catch (error) {
+      console.error(`ALADIN API 호출 실패: ${error.message}`);
+      throw new InternalServerErrorException(
+        `ALADIN API 호출 중 오류 발생: ${error.message}`,
+      );
+    }
+  }
+
+  async fetchManyBook() {
+    const books = await this.fetchManyBookData({ SearchTarget: 'Book' });
+    const foreignBooks = await this.fetchManyBookData({
+      SearchTarget: 'Foreign',
+    });
+    const eBooks = await this.fetchManyBookData({ SearchTarget: 'eBook' });
+
+    return {
+      books: books.item,
+      foreignBooks: foreignBooks.item,
+      eBooks: eBooks.item,
+    };
+  }
+}

--- a/src/modules/book/dto/book.controller.dto.ts
+++ b/src/modules/book/dto/book.controller.dto.ts
@@ -1,0 +1,194 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class AladinBookSeriesDto {
+  @ApiProperty({ description: '시리즈 ID', example: 1026831 })
+  seriesId: number;
+
+  @ApiProperty({
+    description: '시리즈 링크',
+    example:
+      'http://www.aladin.co.kr/shop/common/wseriesitem.aspx?SRID=1026831&amp;partner=openAPI',
+  })
+  seriesLink: string;
+
+  @ApiProperty({ description: '시리즈 이름', example: '한글연습 3' })
+  seriesName: string;
+}
+
+class AladinBookDto {
+  @ApiProperty({ description: '책 제목', example: '한글 워크북 한글연습 3' })
+  title: string;
+
+  @ApiProperty({
+    description: '책 상세 링크',
+    example:
+      'http://www.aladin.co.kr/shop/wproduct.aspx?ItemId=359010178&amp;partner=openAPI&amp;start=api',
+  })
+  link: string;
+
+  @ApiProperty({ description: '저자', example: '재미씨 (지은이)' })
+  author: string;
+
+  @ApiProperty({ description: '출판일', example: '2025-02-10' })
+  pubDate: string;
+
+  @ApiProperty({ description: '설명', example: '' })
+  description: string;
+
+  @ApiProperty({ description: 'ISBN', example: 'K212037082' })
+  isbn: string;
+
+  @ApiProperty({ description: 'ISBN13', example: '9791199127821' })
+  isbn13: string;
+
+  @ApiProperty({ description: '상품 ID', example: 359010178 })
+  itemId: number;
+
+  @ApiProperty({ description: '판매 가격', example: 14400 })
+  priceSales: number;
+
+  @ApiProperty({ description: '정가', example: 16000 })
+  priceStandard: number;
+
+  @ApiProperty({ description: '상품 유형', example: 'BOOK' })
+  mallType: string;
+
+  @ApiProperty({
+    description: '책 표지 이미지 URL',
+    example:
+      'https://image.aladin.co.kr/product/35901/1/coversum/k212037082_1.jpg',
+  })
+  cover: string;
+
+  @ApiProperty({ description: '카테고리 ID', example: 35126 })
+  categoryId: number;
+
+  @ApiProperty({
+    description: '카테고리 이름',
+    example: '국내도서>유아>유아 교양/학습>유아 언어/인지/한글',
+  })
+  categoryName: string;
+
+  @ApiProperty({ description: '출판사', example: '재미씨' })
+  publisher: string;
+
+  @ApiProperty({ description: '성인 도서 여부', example: false })
+  adult: boolean;
+
+  @ApiProperty({ description: '고정 가격 여부', example: true })
+  fixedPrice: boolean;
+
+  @ApiProperty({ description: '시리즈 정보', type: () => AladinBookSeriesDto })
+  seriesInfo: AladinBookSeriesDto;
+}
+
+export class AladinBookResponseDto {
+  @ApiProperty({ type: [AladinBookDto], description: '국내 도서 목록' })
+  domesticBooks: AladinBookDto[];
+
+  @ApiProperty({ type: [AladinBookDto], description: '외국 도서 목록' })
+  foreignBooks: AladinBookDto[];
+
+  @ApiProperty({ type: [AladinBookDto], description: 'eBook 목록' })
+  ebooks: AladinBookDto[];
+}
+
+export class AladinBookDetailDto {
+  @ApiProperty({
+    description: '도서 제목',
+    example: '언더그라운드 레일로드',
+  })
+  title: string;
+
+  @ApiProperty({
+    description: '도서 링크',
+    example: 'http://www.aladin.co.kr/shop/wproduct.aspx?ItemId=358998390',
+  })
+  link: string;
+
+  @ApiProperty({
+    description: '저자',
+    example: '콜슨 화이트헤드 (지은이), 황근하 (옮긴이)',
+  })
+  author: string;
+
+  @ApiProperty({
+    description: '발행일',
+    example: '2017-09-08',
+  })
+  pubDate: string;
+
+  @ApiProperty({
+    description: '도서 설명',
+    example:
+      '미국 평단과 독자를 독시에 사로잡으며 연일 새로운 기록을 세워온 콜슨 화이트헤드 장편소설.',
+  })
+  description: string;
+
+  @ApiProperty({
+    description: '도서 ISBN',
+    example: 'E052635671',
+  })
+  isbn: string;
+
+  @ApiProperty({
+    description: '도서 ISBN-13',
+    example: '9791196171742',
+  })
+  isbn13: string;
+
+  @ApiProperty({
+    description: '도서 가격 (판매 가격)',
+    example: 14500,
+  })
+  priceSales: number;
+
+  @ApiProperty({
+    description: '도서 가격 (정가)',
+    example: 14500,
+  })
+  priceStandard: number;
+
+  @ApiProperty({
+    description: '도서 카테고리',
+    example: 'eBook>소설/시/희곡>영미소설',
+  })
+  categoryName: string;
+
+  @ApiProperty({
+    description: '도서 표지 이미지 URL',
+    example:
+      'https://image.aladin.co.kr/product/35899/83/coversum/e052635671_1.jpg',
+  })
+  cover: string;
+
+  @ApiProperty({
+    description: '출판사',
+    example: '은행나무',
+  })
+  publisher: string;
+
+  @ApiProperty({
+    description: '성인 여부',
+    example: false,
+  })
+  adult: boolean;
+
+  @ApiProperty({
+    description: '고정 가격 여부',
+    example: true,
+  })
+  fixedPrice: boolean;
+
+  @ApiProperty({
+    description: '고객 리뷰 순위',
+    example: 8,
+  })
+  customerReviewRank: number;
+
+  @ApiProperty({
+    description: '추가 정보 (종이책 링크 등)',
+    type: Object,
+  })
+  subInfo: Record<string, any>;
+}

--- a/src/modules/book/dto/get-book-detail.dto.ts
+++ b/src/modules/book/dto/get-book-detail.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class GetBookDetailDto {
+  @ApiProperty({
+    example: '9791196171742',
+    description: 'ISBN 13자리',
+  })
+  @IsString()
+  isbn13: string;
+}


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] 최신 도서 목록 (국내, 해외, ebook) 10개씩 조회 API 구현
  - [x] 도서 상세 조회 API 구현

---

# 🤔 논의가 필요한 사항 (Points to discuss)

<!-- 논의가 필요한 사항, 개선해야 할 부분을 작성해주세요. -->
- [ ] 도서 목록을 각각 10개씩 조회 중인데 너무 많을까요?

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **기능 A**                  | **기능 B**                  |
|-----------------------------|-----------------------------|
| ![기능 A 스크린샷](https://github.com/user-attachments/assets/d775a31b-9e0d-4bc1-b973-38aae08f21c8)    | ![기능 B 스크린샷](https://github.com/user-attachments/assets/195ff077-5a0d-448a-8825-152317de8306)    |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
- [ ] 수정이 필요한 곳이 있다면 수정 하겠습니다.

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->
- **테스트 방법**:
  1. `/book`  도서 목록 조회 가능
  2. `/book/detail` isbn13 코드로 도서 상세 조회 가능
- **참고 자료**: [알라딘 도서 Open API](https://docs.google.com/document/d/1mX-WxuoGs8Hy-QalhHcvuV17n50uGI2Sg_GHofgiePE/edit?tab=t.0)
