### PR TITLE
[Feat] 사용자 정보 수정 API 구현

### DIFF
--- a/src/modules/user/dto/put-user.dto.ts
+++ b/src/modules/user/dto/put-user.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class PutUserDto {
+  @ApiProperty({ description: 'user.nickname', example: '김만사' })
+  @IsNotEmpty({ message: '닉네임은 반드시 입력해야 합니다.' })
+  @IsString({ message: '닉네임은 문자여야 합니다.' })
+  nickname: string;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
@@ -18,6 +19,7 @@ import {
   ApiOperationSummary,
   ApiResponseCreated,
 } from 'src/decorators/swagger-response.decorator';
+import { PutUserDto } from './dto/put-user.dto';
 
 @ApiTags('user')
 @Controller('/users')
@@ -52,5 +54,20 @@ export class UserController {
   @Get('/me')
   async getUser(@CurrentUser() userId: string) {
     return await this.userService.fetchUserByUserId({ userId });
+  }
+
+  @ApiBearerAuth('JWT')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperationSummary('본인 정보 수정', '본인 정보를 수정합니다.')
+  @ApiResponseCreated('본인 정보 수정 성공', GetUserInfoDto)
+  @ApiResponseError('인증 토큰이 없을 경우', 401)
+  @ApiResponseError('존재하지 않는 회원입니다.', 404)
+  @ApiResponseError('닉네임 중복', 400)
+  @Put('/me')
+  async putUser(
+    @CurrentUser() userId: string,
+    @Body() { nickname }: PutUserDto,
+  ) {
+    return await this.userService.modifyUser({ userId, nickname });
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import * as bcrypt from 'bcrypt';
 import { GetUserInfoDto } from './dto/get-user.dto';
@@ -55,5 +59,27 @@ export class UserService {
     }
 
     return plainToInstance(GetUserInfoDto, user);
+  }
+
+  async modifyUser({
+    userId,
+    nickname,
+  }: {
+    userId: string;
+    nickname: string;
+  }): Promise<GetUserInfoDto | null> {
+    await this.fetchUserByUserId({ userId });
+
+    const isAvailable = await this.checkNicknameAvailability(nickname);
+    if (!isAvailable) {
+      throw new BadRequestException('닉네임이 중복됩니다.');
+    }
+
+    const updatedUser = await this.prisma.user.update({
+      where: { id: Number(userId) },
+      data: { nickname },
+    });
+
+    return plainToInstance(GetUserInfoDto, updatedUser);
   }
 }


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] 기능 A : 사용자 정보 확인 API 구현
  - [x] 기능 B : 사용자 정보 수정 API 구현
  - [x] 기타 : 스웨거 독스 따로 정리

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **기능 A**                  | **기능 B**                  |
|-----------------------------|-----------------------------|
| ![기능 A 스크린샷](https://github.com/user-attachments/assets/dcde5233-f958-41ae-a85b-77a80be0e884)    | ![기능 B 스크린샷](https://github.com/user-attachments/assets/8eed498e-5b4b-488f-90da-ef7335137c7c)    |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
- [ ] 수정이 필요한 곳이 있다면 수정 하겠습니다.

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->
- **테스트 방법**:
  1. GET `/users/me` 본인 정보 조회 API 
  2. PUT `/users/me` 도서 정보 수정 API
